### PR TITLE
Add dockerhub context to weekly builds in CircleCI

### DIFF
--- a/{{cookiecutter.project_slug}}/.circleci/config.yml
+++ b/{{cookiecutter.project_slug}}/.circleci/config.yml
@@ -121,7 +121,9 @@ workflows:
               only:
                 - main
     jobs:
-      - build
+      - build:
+          context:
+            - dockerhub
   overcommit:
     jobs:
       - overcommit


### PR DESCRIPTION
Example failed build:

https://app.circleci.com/pipelines/github/apiology/docker-circleci/118/workflows/1ab61935-f73b-480a-b6a9-cb9c29c31c50/jobs/224